### PR TITLE
users can indicated owned media

### DIFF
--- a/client/src/assets/scss/main.scss
+++ b/client/src/assets/scss/main.scss
@@ -38,7 +38,6 @@ body {
 
   .nav-option {
     color: #F9FEFA;
-    ;
   }
 }
 
@@ -148,6 +147,18 @@ body {
   h1 {
     margin-bottom: 25px;
   }
+}
+
+.media-list {
+  margin: 75px 25px 0px 0px; 
+
+  ul {
+    list-style-type: none;
+  }
+}
+
+.media-title {
+  font-weight: bold;
 }
 
 legend, label {

--- a/client/src/assets/scss/main.scss
+++ b/client/src/assets/scss/main.scss
@@ -43,28 +43,48 @@ body {
 
 #home-header {
   background-image: url(./../images/index-page-hero-banner_1600x700.jpg);
+  background-attachment: fixed;
   background-color: #193665;
   background-repeat: no-repeat;
   background-position-x: center;
-  height: 700px;
+  height: 575px;
+  overflow: hidden;
 }
 
 .header-text {
-  padding-top: 150px;
-  padding-left: 200px;
+  background-color: rgba(25,54,101,60%);
+  width: 60%;
+  border-radius: 20px;
   color: #F9FEFA;
+  padding: 20px 0 30px 50px;
+  margin-top: 200px;
+  margin-left: 50px;
+  text-shadow: #F9FEFA 4px 0 10px;
+
+  h1 {
+    font-weight: 200%;
+    font-size: 400%;
+    font-size-adjust: 0.5;
+  }
+
+  h3 {
+    font-size: 250%;
+    font-size-adjust: 0.5;
+  }
 }
 
 #home-media-index {
-  margin: 0px 100px;
+  width: 90%;
+  margin: auto;
 }
 
 .media-tile {
   margin: 20px;
   background-color: #F9FEFA;
   border: 2px solid #193665;
-  box-shadow: 10px 8px 5px #193665;
+  box-shadow: 5px 3px 5px #193665;
   border-radius: 5px;
+  max-width: 300px;
 }
 
 .media-tile-cover {
@@ -74,7 +94,7 @@ body {
 .media-tile-title {
   color: #193665;
   font-weight: bold;
-  font-size: 2em;
+  font-size: larger;
   text-align: center;
   padding-top: 15px;
 }

--- a/client/src/components/layout/AccountPage.js
+++ b/client/src/components/layout/AccountPage.js
@@ -1,15 +1,39 @@
-import React from "react"
+import React, { useState, useEffect } from "react"
 import { Link } from "react-router-dom"
 
 const AccountPage = ({ user }) => {
     const { id, email, type } = user
+    const [ownedMedia, setOwnedMedia] = useState([])
 
-    if (type === "member") {
+    const getUserMedia = async () => {
+        try {
+            const response = await fetch(`/api/v1/owned-media/${id}`)
+            if (!response.ok) {
+                const errorMessage = `${response.status} (${response.statusText})`
+                const error = new Error(errorMessage)
+                throw error
+            }
+            const body = await response.json()
+            setOwnedMedia(body.ownedMedia)
+        } catch (error) {
+            console.error(`Error in fetch: ${error.message}`)
+        }
+    }
+
+    useEffect(() => {
+        getUserMedia()
+    }, [])
+
+    const ownedMediaList = ownedMedia.map(media => {
         return (
-            <div className="non-media-page">
-                <h1>Account</h1>
-                <p>Email: {email}</p>
-            </div>
+            <li key={media.id}><Link to={`../${media.id}`} className="media-title">{media.title}</Link> &mdash; {media.type}</li>
+        )
+    })
+
+    let adminButtons
+    if (type === "admin") {
+        adminButtons = (
+            <Link to="/users/new-media" className="button">Add new media</Link>
         )
     }
     
@@ -17,7 +41,13 @@ const AccountPage = ({ user }) => {
         <div className="non-media-page">
             <h1>Account</h1>
             <p>Email: {email}</p>
-            <Link to="/users/new-media" className="button">Add new media</Link>
+            {adminButtons}
+            <div className="media-list">
+                <h3>Media I Own</h3>
+                <ul>
+                    {ownedMediaList}
+                </ul>
+            </div>
         </div>
     )
 }

--- a/client/src/components/layout/MediaIndex.js
+++ b/client/src/components/layout/MediaIndex.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react"
+import { Redirect } from "react-router-dom"
 
 import MediaTile from "./MediaTile"
 

--- a/client/src/components/layout/MediaIndex.js
+++ b/client/src/components/layout/MediaIndex.js
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from "react"
-import { Redirect } from "react-router-dom"
 
 import MediaTile from "./MediaTile"
 
@@ -39,8 +38,8 @@ const MediaIndex = ({ user }) => {
         <>
             <div id="home-header">
                 <div className="header-text">
-                    <h1>Star Wars</h1>
-                    <h3>an interactive media catalog</h3>
+                    <h1>Holocron</h1>
+                    <h3>an interactive Star Wars media catalog</h3>
                 </div>
             </div>
             <div id="home-media-index" className="grid-x grid-margin-x">

--- a/client/src/components/layout/MediaShow.js
+++ b/client/src/components/layout/MediaShow.js
@@ -2,11 +2,13 @@ import React, { useState, useEffect } from "react"
 import { useParams } from "react-router-dom"
 
 import executeDelete from "../../services/deleteMedia.js"
+import setOwnership from "../../services/setOwnership.js"
 
 const MediaShow = ({ user }) => {
     const [media, setMedia] = useState({
         behindSceneRoles: [],
     })
+    const [shouldRedirect, setShouldRedirect] = useState(false)
     const { id } = useParams()
     
     const getMedia = async () => {
@@ -26,7 +28,7 @@ const MediaShow = ({ user }) => {
 
     useEffect(() => {
         getMedia()
-    }, [])
+    },[])
 
     let directors = []
     let writers = []
@@ -68,6 +70,29 @@ const MediaShow = ({ user }) => {
         return <li key={tag} className={tagName}>{tag}</li>
     })
 
+    const ownMedia = (event) => {
+        event.preventDefault()
+        setOwnership(id, user.id)
+        setShouldRedirect(true)
+    }
+
+    if (shouldRedirect) {
+        location.href=`/${id}`
+    }
+
+    let memberButtons = []
+    if (user) {
+        if (media.isOwned) {
+            memberButtons.push(
+                    <button key="owned" className="button" onClick={ownMedia}>Mark as Unowned</button>
+            )
+        } else {
+            memberButtons.push(
+                <button key="owned" className="button" onClick={ownMedia}>Mark as Owned</button>
+            )
+        }
+    }
+
     const deleteMedia = (event) => {
         event.preventDefault()
         executeDelete(id)
@@ -94,6 +119,7 @@ const MediaShow = ({ user }) => {
                 <p>{media.description}</p>
                 <ul className="tag-bubbles">{tagBubbles}</ul>
                 {adminButtons}
+                {memberButtons}
             </div>
         </div>
     )

--- a/client/src/components/layout/MediaTile.js
+++ b/client/src/components/layout/MediaTile.js
@@ -1,10 +1,35 @@
-import React from "react"
+import React, { useState } from "react"
 import { Link } from "react-router-dom"
 
 import executeDelete from "../../services/deleteMedia.js"
+import setOwnership from "../../services/setOwnership.js"
 
 const MediaTile = ({ item, user }) => {
-    const { id, title, cover_image } = item
+    const { id, title, cover_image, isOwned } = item
+    const [shouldRedirect, setShouldRedirect] = useState(false)
+
+    const ownMedia = (event) => {
+        event.preventDefault()
+        setOwnership(id, user.id)
+        setShouldRedirect(true)
+    }
+
+    if (shouldRedirect) {
+        location.href="/"
+    }
+
+    let memberButtons = []
+    if (user) {
+        if (isOwned) {
+            memberButtons.push(
+                    <button key="owned" className="button" onClick={ownMedia}>Mark as Unowned</button>
+            )
+        } else {
+            memberButtons.push(
+                <button key="owned" className="button" onClick={ownMedia}>Mark as Owned</button>
+            )
+        }
+    }
 
     const deleteMedia = (event) => {
         event.preventDefault()
@@ -25,6 +50,9 @@ const MediaTile = ({ item, user }) => {
             <img src={cover_image} className="media-tile-cover"/>
             <p className="media-tile-title">{title}</p>
             {adminButtons}
+            <div className="tile-member-buttons">
+                {memberButtons}
+            </div>
         </Link> 
     )  
 } 

--- a/client/src/components/layout/TopBar.js
+++ b/client/src/components/layout/TopBar.js
@@ -27,7 +27,7 @@ const TopBar = ({ user }) => {
     <div className="top-bar">
       <div className="top-bar-left">
         <ul className="menu">
-          <li className="menu-text">Star Wars Media Catalog</li>
+          <li className="menu-text">Holocron</li>
           <li>
             <Link to="/" className="nav-option">Home</Link>
           </li>

--- a/client/src/services/setOwnership.js
+++ b/client/src/services/setOwnership.js
@@ -1,0 +1,20 @@
+const setOwnership = async (mediaId, userId) => {
+    const relationship = {mediaId, userId}
+    
+    try {
+        const response = await fetch(`/api/v1/owned-media/${mediaId}`, {
+            method: "POST",
+            headers: new Headers({"Content-Type":"application/json"}),
+            body: JSON.stringify(relationship)
+        })
+        if (!response.ok) {
+            const errorMessage = `${response.status} (${response.statusText})`
+            const error = new Error(errorMessage)
+            throw error
+        }
+    } catch (error) {
+        console.error(`Error in fetch: ${error.message}`)
+    }
+}
+
+export default setOwnership

--- a/server/src/db/migrations/20231120202125_createUserOwns.cjs
+++ b/server/src/db/migrations/20231120202125_createUserOwns.cjs
@@ -1,0 +1,23 @@
+/**
+ * @typedef {import("knex")} Knex
+ */
+
+/**
+ * @param {Knex} knex
+ */
+exports.up = async (knex) => {
+    return knex.schema.createTable("userOwns", (table) => {
+        table.bigIncrements("id").notNullable()
+        table.bigInteger("userId").notNullable().unsigned().index().references("users.id")
+        table.bigInteger("mediaId").notNullable().unsigned().index().references("media.id")
+        table.timestamp("createdAt").notNullable().defaultTo(knex.fn.now())
+        table.timestamp("updatedAt").notNullable().defaultTo(knex.fn.now())
+    })
+}
+
+/**
+ * @param {Knex} knex
+ */
+exports.down = (knex) => {
+    return knex.schema.dropTableIfExists("userOwns")
+}

--- a/server/src/models/Media.js
+++ b/server/src/models/Media.js
@@ -26,7 +26,7 @@ class Media extends Model {
     }
 
     static get relationMappings() {
-        const { Contributor, BehindSceneRole } = require("./index.js")
+        const { Contributor, BehindSceneRole, OwnedMedia, User } = require("./index.js")
 
         return {
             behindSceneRoles: {
@@ -47,6 +47,26 @@ class Media extends Model {
                         to: "behindSceneRoles.contributorId"
                     },
                     to: "contributors.id"
+                }
+            },
+            ownedBy: {
+                relation: Model.HasManyRelation,
+                modelClass: OwnedMedia,
+                join: {
+                    from: "media.id",
+                    to: "userOwns.mediaId"
+                }
+            },
+            users: {
+                relation: Model.ManyToManyRelation,
+                modelClass: User,
+                join: {
+                    from: "media.id",
+                    through: {
+                        from: "userOwns.mediaId",
+                        to: "userOwns.userId"
+                    },
+                    to: "users.id"
                 }
             }
         }

--- a/server/src/models/OwnedMedia.js
+++ b/server/src/models/OwnedMedia.js
@@ -1,0 +1,43 @@
+const Model = require("./Model.js")
+
+class OwnedMedia extends Model {
+    static get tableName() {
+        return "userOwns"
+    }
+
+    static get jsonSchema() {
+        return {
+            type: "object",
+            required: ["userId", "mediaId"],
+            properties: {
+                userId: { type: ["integer", "string"] },
+                mediaId: { type: ["integer", "string"] }
+            }
+        }
+    }
+
+    static get relationMappings() {
+        const { User, Media } = require("./index.js")
+
+        return {
+            user: {
+                relation: Model.BelongsToOneRelation,
+                modelClass: User,
+                join: {
+                    from: "userOwns.userId",
+                    to: "users.id"
+                }
+            },
+            media: {
+                relation: Model.BelongsToOneRelation,
+                modelClass: Media,
+                join: {
+                    from: "userOwns.mediaId",
+                    to: "media.id"
+                }
+            }
+        }
+    }
+}
+
+module.exports = OwnedMedia

--- a/server/src/models/User.js
+++ b/server/src/models/User.js
@@ -44,6 +44,33 @@ class User extends uniqueFunc(Model) {
 
     return serializedJson;
   }
+
+  static get relationMappings() {
+    const { Media, OwnedMedia } = require("./index.js")
+
+    return {
+      media: {
+        relation: Model.ManyToManyRelation,
+        modelClass: Media,
+        join: {
+          from: "users.id",
+          through: {
+            from: "userOwns.userId",
+            to: "userOwns.mediaId"
+          },
+          to: "media.id"
+        }
+      },
+      owns: {
+        relation: Model.HasManyRelation,
+        modelClass: OwnedMedia,
+        join: {
+          from: "users.id",
+          to: "userOwns.userId"
+        }
+      }
+    }
+  }
 }
 
 module.exports = User;

--- a/server/src/models/index.js
+++ b/server/src/models/index.js
@@ -1,7 +1,8 @@
 // include all of your models here using CommonJS requires
 const User = require("./User.js")
+const OwnedMedia = require("./OwnedMedia.js")
 const Media = require("./Media.js")
 const Contributor = require("./Contributor.js");
 const BehindSceneRole = require("./BehindSceneRole.js");
 
-module.exports = { User, Media, Contributor, BehindSceneRole };
+module.exports = { User, Media, Contributor, BehindSceneRole, OwnedMedia };

--- a/server/src/routes/api/v1/ownedMediaRouter.js
+++ b/server/src/routes/api/v1/ownedMediaRouter.js
@@ -1,0 +1,40 @@
+import express from "express"
+
+import { Media, User } from "../../../models/index.js"
+import MediaSerializer from "../../../serializers/MediaSerializer.js"
+
+const ownedMediaRouter = new express.Router()
+
+ownedMediaRouter.post("/:mediaId", async (req,res) => {
+    const body = req.body
+    const { mediaId, userId } = body
+
+    try {
+        const media = await Media.query().findById(mediaId)
+        const user = await User.query().findById(userId)
+        const currentRelationship = await media.$relatedQuery('users').where('userId', userId)
+        if (currentRelationship.length > 0) {
+            await media.$relatedQuery('users').unrelate().where('userId', userId)
+        }
+        else {
+            await media.$relatedQuery('users').relate(user)
+        }
+        return res.status(201)
+    } catch (error) {
+        return res.status(500).json({ errors: error })
+    }
+})
+
+ownedMediaRouter.get("/:userId", async (req, res) => {
+    const id = req.params.userId
+    try {
+        const user = await User.query().findById(id)
+        const ownedMedia = await user.$relatedQuery('media')
+        const serializedMedia = MediaSerializer.getTitleAndType(ownedMedia)
+        return res.status(200).json({ ownedMedia: ownedMedia })
+    } catch (error) {
+        return res.status(500).json({ errors: error })
+    }
+})
+
+export default ownedMediaRouter

--- a/server/src/routes/rootRouter.js
+++ b/server/src/routes/rootRouter.js
@@ -3,13 +3,13 @@ import userSessionsRouter from "./api/v1/userSessionsRouter.js";
 import usersRouter from "./api/v1/usersRouter.js";
 import clientRouter from "./clientRouter.js";
 import mediaRouter from "./api/v1/mediaRouter.js";
+import ownedMediaRouter from "./api/v1/ownedMediaRouter.js";
 const rootRouter = new express.Router();
 
 rootRouter.use("/", clientRouter);
 rootRouter.use("/api/v1/user-sessions", userSessionsRouter);
 rootRouter.use("/api/v1/users", usersRouter);
 rootRouter.use("/api/v1/media", mediaRouter)
-
-//place your server-side routes here
+rootRouter.use("/api/v1/owned-media", ownedMediaRouter)
 
 export default rootRouter;

--- a/server/src/serializers/MediaSerializer.js
+++ b/server/src/serializers/MediaSerializer.js
@@ -1,7 +1,7 @@
 import RoleSerializer from "./RoleSerializer.js"
 
 class MediaSerializer {
-    static async getContributors(media) {
+    static async getContributors(media, userId) {
         const allowedAttributes = ["id", "type", "title", "cover_image", "release_date", "description", "fictional_year_start", "fictional_year_end", "canon", "animated", "lego", "rating"]
         const serializedMedia = {}
         
@@ -11,14 +11,53 @@ class MediaSerializer {
 
         const roles = await media.$relatedQuery("behindSceneRoles")
         const serializedRoles = await RoleSerializer.getContributors(roles)
-        
         serializedMedia.behindSceneRoles = serializedRoles
+
+        if (userId) {
+            const isOwned = await media.$relatedQuery('users').where('userId', userId)
+            if (isOwned.length > 0) {
+                serializedMedia.isOwned = true
+            } else {
+                serializedMedia.isOwned = false
+            }
+        }
 
         return serializedMedia
     }
     
-    static getCoverAndTitle(media) {
+    static async getCoverAndTitle(media, userId) {
         const allowedAttributes = ["id", "title", "cover_image"]
+        
+        if (userId) {
+            const serializedMedia = await Promise.all(media.map(async (item) => {
+                let serializedItem = {}
+                for (const attribute of allowedAttributes) {
+                    serializedItem[attribute] = item[attribute]
+                }
+    
+                const isOwned = await item.$relatedQuery('users').where('userId', userId)
+                if (isOwned.length > 0) {
+                    serializedItem.isOwned = true
+                }
+    
+                return serializedItem
+            }))
+            return serializedMedia
+        } else {
+            const serializedMedia = media.map(item => {
+                let serializedItem = {}
+                for (const attribute of allowedAttributes) {
+                    serializedItem[attribute] = item[attribute]
+                }
+    
+                return serializedItem
+            })
+            return serializedMedia
+        }
+    }
+
+    static getTitleAndType(media) {
+        const allowedAttributes = ["id", "title", "type"]
         const serializedMedia = media.map(item => {
             let serializedItem = {}
             for (const attribute of allowedAttributes) {


### PR DESCRIPTION
- created "owns" table migration and Model
- set up relationMappings() between User, OwnedMedia, and Media
- added file setOwnership with function to fetch and related media to current user
- passed function to button that appears on show page and also each media tile on index page
- updated mediaRouter to pass signed-in user information to backend and serialize media to indicate whether user-media relationship exists in "owns" join table
- depending on user-media relationship, button renders either "Mark as Owned" or "Mark as Unowned"
- clicking button toggles relationship
- added AccountPage fetch to get user's related media data and display on page